### PR TITLE
Add helpers to create PWHashStr externally.

### DIFF
--- a/pwhash.go
+++ b/pwhash.go
@@ -29,6 +29,11 @@ type PWHashStr struct {
 	string
 }
 
+// NewPWHashStr constructs a PWHashStr for a string value.
+func NewPWHashStr(value string) PWHashStr {
+	return PWHashStr{value}
+}
+
 func PWHashDefault(t Typed, pw string, salt PWHashSalt) {
 	PWHash(t, pw, salt, CryptoPWHashOpsLimitInteractive, CryptoPWHashMemLimitInteractive)
 }
@@ -98,4 +103,9 @@ func (s PWHashStr) PWHashVerify(pw string) (err error) {
 		err = ErrPassword
 	}
 	return
+}
+
+// Value returns the string value of the PWHashStr.
+func (s PWHashStr) Value() string {
+	return s.string
 }

--- a/sodium_test.go
+++ b/sodium_test.go
@@ -250,6 +250,14 @@ func ExamplePWHashStore() {
 	//Output: <nil>
 }
 
+func ExamplePWHashStoreFromString() {
+	hash := PWHashStore("test").Value()
+	err := NewPWHashStr(hash).PWHashVerify("test")
+
+	fmt.Println(err)
+	//Output: <nil>
+}
+
 func ExampleSignKP_ToBox() {
 	skp := MakeSignKP()
 	bkp := skp.ToBox()


### PR DESCRIPTION
This PR adds helper functions to:
- get a `string` value from `PWHashStr`
- create  `PWHashStr` from a `string` value

Reason:

I would like to store the `string`-value of `PWHashStr` into a database. Later on I want to fetch the `string`-value from the database, construct a new `PWHashStr` and use its `PWHashVerify()` function to verify against the password the user sends me.

Problem, which is fixed with this PR:
1. `PWHashStr` embeds an unexported type `string`, which I cannot access without reflection for getting the `value`. Therefore I added a `Value() string` function to `PWHashStr`.
2.  And I cannot create a new `PWHashStr{"myhash}"` since it is unexported (implicit assignment of unexported field 'string' in sodium.PWHashStr literal). Therefore I added a `NewPWHashStr(value string) PWHashStr` function.

Side note:

The fact that this is an unexported `string`, instead of providing a:

```
type PWHashStr {
   Value string
}
```

is probably good, so nobody can mess around with `Value` after construction.
